### PR TITLE
Add CRUD endpoints for Games API

### DIFF
--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -121,6 +121,8 @@ def create_game() -> tuple[Response, int]:
     """
     try:
         data = request.get_json()
+        if not isinstance(data, dict):
+            return jsonify({"error": "Request body must be a JSON object"}), 400
         
         # Validate required fields
         required_fields = ['title', 'description', 'publisher_id', 'category_id']

--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -199,7 +199,7 @@ def update_game(id: int) -> tuple[Response, int]:
             game.publisher_id = data['publisher_id']
         if 'category_id' in data:
             if not db.session.get(Category, data['category_id']):
-                return jsonify({"error": "Invalid category_id"}), 400
+                return jsonify({"error": f"Category with id {data['category_id']} not found"}), 400
             game.category_id = data['category_id']
         if 'star_rating' in data:
             game.star_rating = data['star_rating']

--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -3,12 +3,15 @@ Games API Routes Module
 
 This module provides the API routes for game-related operations in the
 Tailspin Toys crowdfunding platform. It includes endpoints for retrieving
-all games and individual game details.
+all games and individual game details, as well as creating, updating and
+deleting games.
 """
 
-from flask import jsonify, Response, Blueprint
+from flask import jsonify, Response, Blueprint, request
 from models import db, Game, Publisher, Category
 from sqlalchemy.orm import Query
+from sqlalchemy.exc import SQLAlchemyError
+from typing import Tuple
 
 # Create a Blueprint for games routes
 games_bp = Blueprint('games', __name__)
@@ -96,3 +99,146 @@ def get_game(id: int) -> tuple[Response, int] | Response:
     game = game_query.to_dict()
     
     return jsonify(game)
+
+@games_bp.route('/api/games', methods=['POST'])
+def create_game() -> tuple[Response, int]:
+    """
+    Create a new game endpoint.
+    
+    Creates a new game in the database with the provided information.
+    
+    Expected request body:
+        - title: The game's title (required)
+        - description: The game's description (required)
+        - publisher_id: ID of the publisher (required)
+        - category_id: ID of the category (required)
+        - star_rating: Optional rating score for the game
+        
+    Returns:
+        Response: JSON response containing the created game object if successful,
+                 or an error message if validation fails
+        int: HTTP status code (201 if created, 400 for invalid data)
+    """
+    try:
+        data = request.get_json()
+        
+        # Validate required fields
+        required_fields = ['title', 'description', 'publisher_id', 'category_id']
+        if not all(field in data for field in required_fields):
+            return jsonify({"error": "Missing required fields"}), 400
+        
+        # Verify publisher and category exist
+        publisher = db.session.get(Publisher, data['publisher_id'])
+        category = db.session.get(Category, data['category_id'])
+        
+        if not publisher or not category:
+            return jsonify({"error": "Invalid publisher_id or category_id"}), 400
+        
+        # Create new game
+        new_game = Game(
+            title=data['title'],
+            description=data['description'],
+            publisher_id=data['publisher_id'],
+            category_id=data['category_id'],
+            star_rating=data.get('star_rating')  # Optional field
+        )
+        
+        db.session.add(new_game)
+        db.session.commit()
+        
+        # Return the created game
+        return jsonify(new_game.to_dict()), 201
+        
+    except ValueError as e:
+        # Handle validation errors from the model
+        return jsonify({"error": str(e)}), 400
+    except SQLAlchemyError as e:
+        # Handle database errors
+        db.session.rollback()
+        return jsonify({"error": "Database error occurred"}), 500
+
+@games_bp.route('/api/games/<int:id>', methods=['PUT'])
+def update_game(id: int) -> tuple[Response, int]:
+    """
+    Update a game endpoint.
+    
+    Updates an existing game in the database with the provided information.
+    
+    Args:
+        id (int): The unique identifier of the game to update.
+        
+    Expected request body:
+        - title: The game's new title (optional)
+        - description: The game's new description (optional)
+        - publisher_id: New publisher ID (optional)
+        - category_id: New category ID (optional)
+        - star_rating: New rating score (optional)
+        
+    Returns:
+        Response: JSON response containing the updated game object if successful,
+                 or an error message if validation fails or game not found
+        int: HTTP status code (200 if updated, 404 if not found, 400 for invalid data)
+    """
+    try:
+        game = db.session.get(Game, id)
+        if not game:
+            return jsonify({"error": "Game not found"}), 404
+            
+        data = request.get_json()
+        
+        # Update fields if provided
+        if 'title' in data:
+            game.title = data['title']
+        if 'description' in data:
+            game.description = data['description']
+        if 'publisher_id' in data:
+            if not db.session.get(Publisher, data['publisher_id']):
+                return jsonify({"error": "Invalid publisher_id"}), 400
+            game.publisher_id = data['publisher_id']
+        if 'category_id' in data:
+            if not db.session.get(Category, data['category_id']):
+                return jsonify({"error": "Invalid category_id"}), 400
+            game.category_id = data['category_id']
+        if 'star_rating' in data:
+            game.star_rating = data['star_rating']
+            
+        db.session.commit()
+        
+        return jsonify(game.to_dict())
+        
+    except ValueError as e:
+        # Handle validation errors from the model
+        return jsonify({"error": str(e)}), 400
+    except SQLAlchemyError as e:
+        # Handle database errors
+        db.session.rollback()
+        return jsonify({"error": "Database error occurred"}), 500
+
+@games_bp.route('/api/games/<int:id>', methods=['DELETE'])
+def delete_game(id: int) -> tuple[Response, int]:
+    """
+    Delete a game endpoint.
+    
+    Removes a game from the database.
+    
+    Args:
+        id (int): The unique identifier of the game to delete.
+        
+    Returns:
+        Response: Empty response if successful, or error message if game not found
+        int: HTTP status code (204 if deleted, 404 if not found)
+    """
+    try:
+        game = db.session.get(Game, id)
+        if not game:
+            return jsonify({"error": "Game not found"}), 404
+            
+        db.session.delete(game)
+        db.session.commit()
+        
+        return '', 204
+        
+    except SQLAlchemyError as e:
+        # Handle database errors
+        db.session.rollback()
+        return jsonify({"error": "Database error occurred"}), 500

--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -195,7 +195,7 @@ def update_game(id: int) -> tuple[Response, int]:
             game.description = data['description']
         if 'publisher_id' in data:
             if not db.session.get(Publisher, data['publisher_id']):
-                return jsonify({"error": "Invalid publisher_id"}), 400
+                return jsonify({"error": f"Publisher with id {data['publisher_id']} not found"}), 400
             game.publisher_id = data['publisher_id']
         if 'category_id' in data:
             if not db.session.get(Category, data['category_id']):

--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -199,7 +199,7 @@ def update_game(id: int) -> tuple[Response, int]:
             game.publisher_id = data['publisher_id']
         if 'category_id' in data:
             if not db.session.get(Category, data['category_id']):
-                return jsonify({"error": f"Category with id {data['category_id']} not found"}), 400
+                return jsonify({"error": "Invalid category_id"}), 400
             game.category_id = data['category_id']
         if 'star_rating' in data:
             game.star_rating = data['star_rating']

--- a/server/tests/test_games.py
+++ b/server/tests/test_games.py
@@ -296,7 +296,7 @@ class TestGamesRoutes(unittest.TestCase):
         # Assert
         self.assertEqual(response.status_code, 400)
         self.assertIn('error', data)
-        self.assertEqual(data['error'], "Invalid publisher_id")
+        self.assertEqual(data['error'], "Publisher with id 999 not found")
 
         # Act - Try to update with non-existent category
         update_data = {

--- a/server/tests/test_games.py
+++ b/server/tests/test_games.py
@@ -168,5 +168,105 @@ class TestGamesRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(data['error'], "Game not found")
 
+    def test_create_game_success(self) -> None:
+        """Test successful creation of a game"""
+        # Arrange
+        new_game = {
+            "title": "Test Game",
+            "description": "A test game description that is long enough",
+            "publisher_id": 1,  # Using existing publisher from test data
+            "category_id": 1,   # Using existing category from test data
+            "star_rating": 4.0
+        }
+
+        # Act
+        response = self.client.post(self.GAMES_API_PATH, json=new_game)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(data['title'], new_game['title'])
+        self.assertEqual(data['description'], new_game['description'])
+        self.assertEqual(data['starRating'], new_game['star_rating'])
+        self.assertIsNotNone(data['id'])
+
+    def test_create_game_invalid_data(self) -> None:
+        """Test game creation with invalid data"""
+        # Arrange
+        invalid_game = {
+            "title": "A",  # Too short
+            "description": "Too short",  # Too short
+            "publisher_id": 999,  # Non-existent
+            "category_id": 999    # Non-existent
+        }
+
+        # Act
+        response = self.client.post(self.GAMES_API_PATH, json=invalid_game)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', data)
+
+    def test_update_game_success(self) -> None:
+        """Test successful update of a game"""
+        # Arrange - Get an existing game
+        response = self.client.get(self.GAMES_API_PATH)
+        games = self._get_response_data(response)
+        game_id = games[0]['id']
+
+        update_data = {
+            "title": "Updated Game Title",
+            "description": "An updated description that is definitely long enough",
+            "star_rating": 4.8
+        }
+
+        # Act
+        response = self.client.put(f'{self.GAMES_API_PATH}/{game_id}', json=update_data)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['title'], update_data['title'])
+        self.assertEqual(data['description'], update_data['description'])
+        self.assertEqual(data['starRating'], update_data['star_rating'])
+
+    def test_update_game_not_found(self) -> None:
+        """Test updating a non-existent game"""
+        # Act
+        response = self.client.put(f'{self.GAMES_API_PATH}/999', json={"title": "New Title"})
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(data['error'], "Game not found")
+
+    def test_delete_game_success(self) -> None:
+        """Test successful deletion of a game"""
+        # Arrange - Get an existing game
+        response = self.client.get(self.GAMES_API_PATH)
+        games = self._get_response_data(response)
+        game_id = games[0]['id']
+
+        # Act
+        response = self.client.delete(f'{self.GAMES_API_PATH}/{game_id}')
+
+        # Assert
+        self.assertEqual(response.status_code, 204)
+
+        # Verify game is deleted
+        response = self.client.get(f'{self.GAMES_API_PATH}/{game_id}')
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_game_not_found(self) -> None:
+        """Test deleting a non-existent game"""
+        # Act
+        response = self.client.delete(f'{self.GAMES_API_PATH}/999')
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(data['error'], "Game not found")
+
 if __name__ == '__main__':
     unittest.main()

--- a/server/tests/test_games.py
+++ b/server/tests/test_games.py
@@ -241,6 +241,75 @@ class TestGamesRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(data['error'], "Game not found")
 
+    def test_update_game_invalid_title(self) -> None:
+        """Test updating a game with an invalid title"""
+        # Arrange - Get an existing game
+        response = self.client.get(self.GAMES_API_PATH)
+        games = self._get_response_data(response)
+        game_id = games[0]['id']
+
+        # Act - Try to update with too short title
+        update_data = {
+            "title": "A"  # Too short, minimum is 2 characters
+        }
+        response = self.client.put(f'{self.GAMES_API_PATH}/{game_id}', json=update_data)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', data)
+        self.assertIn('Game title', data['error'])
+
+    def test_update_game_invalid_description(self) -> None:
+        """Test updating a game with an invalid description"""
+        # Arrange - Get an existing game
+        response = self.client.get(self.GAMES_API_PATH)
+        games = self._get_response_data(response)
+        game_id = games[0]['id']
+
+        # Act - Try to update with too short description
+        update_data = {
+            "description": "Too short"  # Too short, minimum is 10 characters
+        }
+        response = self.client.put(f'{self.GAMES_API_PATH}/{game_id}', json=update_data)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', data)
+        self.assertIn('Description', data['error'])
+
+    def test_update_game_invalid_relationships(self) -> None:
+        """Test updating a game with invalid publisher or category IDs"""
+        # Arrange - Get an existing game
+        response = self.client.get(self.GAMES_API_PATH)
+        games = self._get_response_data(response)
+        game_id = games[0]['id']
+
+        # Act - Try to update with non-existent publisher
+        update_data = {
+            "publisher_id": 999  # Non-existent publisher
+        }
+        response = self.client.put(f'{self.GAMES_API_PATH}/{game_id}', json=update_data)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', data)
+        self.assertEqual(data['error'], "Invalid publisher_id")
+
+        # Act - Try to update with non-existent category
+        update_data = {
+            "category_id": 999  # Non-existent category
+        }
+        response = self.client.put(f'{self.GAMES_API_PATH}/{game_id}', json=update_data)
+        data = self._get_response_data(response)
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', data)
+        self.assertEqual(data['error'], "Invalid category_id")
+
     def test_delete_game_success(self) -> None:
         """Test successful deletion of a game"""
         # Arrange - Get an existing game


### PR DESCRIPTION
This PR adds new endpoints to the Games API to support creating, updating, and deleting games. Changes include:

- Added POST endpoint `/api/games` to create new games
- Added PUT endpoint `/api/games/<id>` to update existing games
- Added DELETE endpoint `/api/games/<id>` to remove games
- Added comprehensive test coverage for all new endpoints
- Implemented proper error handling and validation
- Updated to use modern SQLAlchemy session.get() methods

The changes follow RESTful API design principles and include validation for:
- Required fields
- Valid relationships (publisher and category must exist)
- String length requirements for title and description

All tests are passing and the code has been tested for various scenarios including:
- Successful operations
- Invalid data handling
- Not found cases
- Relationship validation

Closes #7